### PR TITLE
Add support for other countries

### DIFF
--- a/callattendant/app.cfg.example
+++ b/callattendant/app.cfg.example
@@ -24,6 +24,42 @@ TESTING = False
 #   This should not be changed/overrriden except during development/testing
 #DATABASE = "callattendant.db"
 
+# PHONE_DISPLAY_SEPARATOR: Specify the character used to format phone numbers, e.g, a space, hyphen or period,
+PHONE_DISPLAY_SEPARATOR = "-"
+
+# PHONE_DISPLAY_FORMAT: Define the formatting of phone numbers in the various lists. You must use the
+# separator character defined by PHONE_DISPLAY_SEPARATOR above in the format string.
+#
+#   The phone display format handles variable length phone numbers. Excess digits not included
+#   in the format string are prepended to the number with a separator.
+#   For example, the AUS number 006173XXXYYYY would be formatted as follows:
+#       General format: 006173-XXX-YYYY
+#            AU format: 00-61-73-XXX-YYYY
+#            US format: 006-173-XXX-YYYY
+#            UK format: 00-6173-XXX-YYYY
+#            FR format: 0061-73X-XX-YY-YY
+#
+#  Example: General
+#   PHONE_DISPLAY_FORMAT = "###-####"
+#
+#  Example: US
+#   PHONE_DISPLAY_FORMAT = "###-###-####"
+#
+#  Example: UK
+#   PHONE_DISPLAY_FORMAT = "####-###-####"
+#
+#  Example: FR
+#   PHONE_DISPLAY_FORMAT = "###-##-##-##"
+#
+#  Example: AU
+#   PHONE_DISPLAY_FORMAT = "##-##-###-####"
+#
+#  Example: Raw - no formatting
+#  PHONE_DISPLAY_FORMAT = ""
+#
+PHONE_DISPLAY_FORMAT = "###-###-####"
+
+
 # SCREENING_MODE: A tuple containing: "whitelist" and/or "blacklist", or empty
 SCREENING_MODE = ("whitelist", "blacklist")
 

--- a/callattendant/app.cfg.example
+++ b/callattendant/app.cfg.example
@@ -74,6 +74,14 @@ BLOCK_NAME_PATTERNS = {"V[0-9]{15}": "Telemarketer Caller ID", }
 #   Example: {"P": "Private number", "O": "Out of area",}
 BLOCK_NUMBER_PATTERNS = {}
 
+# BLOCK_SERVICE: The name of the online service used to lookup robocallers and spam numbers.
+#   Currently, only NOMOROBO is supported and it is for the USA. Areas outside the USA should set
+#   to blank. When the online service is blank (disabled), only the blacklist and blocked
+#   name/number patterns are used to block numbers.
+#
+#   Example: "NOMOROBO" (USA)  or "" (disabled).
+BLOCK_SERVICE = "NOMOROBO"
+
 
 # BLOCKED_ACTIONS: A tuple containing a combination of the following actions:
 #   "greeting", "record_message", "voice_mail".

--- a/callattendant/app.py
+++ b/callattendant/app.py
@@ -26,6 +26,7 @@ import os
 import sys
 import queue
 import sqlite3
+import time
 from pprint import pprint
 from shutil import copyfile
 
@@ -114,6 +115,10 @@ class CallAttendant(object):
 
         # Instruct the modem to start feeding calls into the caller queue
         self.modem.handle_calls(self.handle_caller)
+
+        # If testing, allow queue to be filled before processing for clean, readable logs
+        if self.config["TESTING"]:
+            time.sleep(1)
 
         # Process incoming calls
         while 1:

--- a/callattendant/config.py
+++ b/callattendant/config.py
@@ -28,6 +28,9 @@ default_config = {
     "DATABASE": "callattendant.db",
     "SCREENING_MODE": ("whitelist", "blacklist"),
 
+    "PHONE_DISPLAY_SEPARATOR": "-",
+    "PHONE_DISPLAY_FORMAT": "###-###-####",
+
     "BLOCK_ENABLED": True,
     "BLOCK_NAME_PATTERNS": {"V[0-9]{15}": "Telemarketer Caller ID", },
     "BLOCK_NUMBER_PATTERNS": {},

--- a/callattendant/config.py
+++ b/callattendant/config.py
@@ -32,6 +32,7 @@ default_config = {
     "PHONE_DISPLAY_FORMAT": "###-###-####",
 
     "BLOCK_ENABLED": True,
+    "BLOCK_SERVICE": "NOMOROBO",
     "BLOCK_NAME_PATTERNS": {"V[0-9]{15}": "Telemarketer Caller ID", },
     "BLOCK_NUMBER_PATTERNS": {},
 

--- a/callattendant/screening/callscreener.py
+++ b/callattendant/screening/callscreener.py
@@ -62,14 +62,15 @@ class CallScreener(object):
                         reason = block["number_patterns"][key]
                         print(reason)
                         return True, reason
-                print(">> Checking nomorobo...")
-                result = self._nomorobo.lookup_number(number)
-                if result["spam"]:
-                    reason = "{} with score {}".format(result["reason"], result["score"])
-                    if self.config["DEBUG"]:
-                        print(">>> {}".format(reason))
-                    self.blacklist_caller(callerid, reason)
-                    return True, reason
+                if block["service"].upper() == "NOMOROBO":
+                    print(">> Checking nomorobo...")
+                    result = self._nomorobo.lookup_number(number)
+                    if result["spam"]:
+                        reason = "{} with score {}".format(result["reason"], result["score"])
+                        if self.config["DEBUG"]:
+                            print(">>> {}".format(reason))
+                        self.blacklist_caller(callerid, reason)
+                        return True, reason
                 print("Caller has been screened")
                 return False, "Not found"
         finally:

--- a/callattendant/userinterface/templates/callers_blocked.html
+++ b/callattendant/userinterface/templates/callers_blocked.html
@@ -68,9 +68,8 @@
         <form>
           <div class="modal-body">
               <div class="form-group">
-                <label for="add-phone" class="col-form-label">Phone: ...-...-....</label>
-                <input name="phone" type="tel" class="form-control" id="add-phone" required="required"
-                    pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}" >
+                <label for="add-phone" class="col-form-label">Phone: {{ phone_no_format }}</label>
+                <input name="phone" type="tel" class="form-control" id="add-phone" required="required" >
               </div>
               <div class="form-group">
                 <label for="add-name" class="col-form-label">Name:</label>

--- a/callattendant/userinterface/templates/callers_permitted.html
+++ b/callattendant/userinterface/templates/callers_permitted.html
@@ -73,9 +73,8 @@
         <form>
           <div class="modal-body">
               <div class="form-group">
-                <label for="add-phone" class="col-form-label">Phone: ...-...-....</label>
-                <input name="phone" type="tel" class="form-control" id="add-phone" required="required"
-                    pattern="[0-9]{3}-[0-9]{3}-[0-9]{4}" >
+                <label for="add-phone" class="col-form-label">Phone: {{ phone_no_format }}</label>
+                <input name="phone" type="tel" class="form-control" id="add-phone" required="required" >
               </div>
               <div class="form-group">
                 <label for="add-name" class="col-form-label">Name:</label>

--- a/callattendant/userinterface/webapp.py
+++ b/callattendant/userinterface/webapp.py
@@ -273,8 +273,7 @@ def calls():
     search_criteria = ""
     if search_text:
         if search_type == "phone":
-            num_list = re.findall('[0-9]+', search_text)
-            number = "".join(num_list)  # override GET arg if we're searching
+            number = transform_number(search_text)  # override GET arg if we're searching
             search_criteria = "WHERE Number='{}'".format(number)
         else:
             search_criteria = "WHERE Caller LIKE '%{}%'".format(search_text)
@@ -448,7 +447,7 @@ def callers_manage(call_no):
 
     # Post changes to the blacklist or whitelist table before rendering
     if request.method == 'POST':
-        number = strip_phone_no(request.form['phone_no'])
+        number = transform_number(request.form['phone_no'])
         if request.form['action'] == 'add-permit':
             caller = {}
             caller['NMBR'] = number
@@ -578,7 +577,7 @@ def callers_blocked_add():
     Add a new blacklist entry
     """
     caller = {}
-    number = strip_phone_no(request.form["phone"])
+    number = transform_number(request.form["phone"])
     caller['NMBR'] = number
     caller['NAME'] = request.form["name"]
     print("Adding " + number + " to blacklist")
@@ -596,7 +595,7 @@ def callers_blocked_update(phone_no):
     """
     Update the blacklist entry associated with the phone number.
     """
-    number = strip_phone_no(phone_no)
+    number = transform_number(phone_no)
     print("Updating " + number + " in blacklist")
     blacklist = Blacklist(get_db(), current_app.config)
     blacklist.update_number(number, request.form['name'], request.form['reason'])
@@ -609,7 +608,7 @@ def callers_blocked_delete(phone_no):
     """
     Delete the blacklist entry associated with the phone number.
     """
-    number = strip_phone_no(phone_no)
+    number = transform_number(phone_no)
 
     print("Removing " + number + " from blacklist")
     blacklist = Blacklist(get_db(), current_app.config)
@@ -670,7 +669,7 @@ def callers_permitted_add():
     Add a new whitelist entry
     """
     caller = {}
-    number = strip_phone_no(request.form['phone'])
+    number = transform_number(request.form['phone'])
     caller['NMBR'] = number
     caller['NAME'] = request.form['name']
     print("Adding " + number + " to whitelist")
@@ -688,7 +687,7 @@ def callers_permitted_update(phone_no):
     """
     Update the whitelist entry associated with the phone number.
     """
-    number = strip_phone_no(phone_no)
+    number = transform_number(phone_no)
 
     print("Updating " + number + " in whitelist")
     whitelist = Whitelist(get_db(), current_app.config)
@@ -702,7 +701,7 @@ def callers_permitted_delete(phone_no):
     """
     Delete the whitelist entry associated with the phone number.
     """
-    number = strip_phone_no(phone_no)
+    number = transform_number(phone_no)
 
     print("Removing " + number + " from whitelist")
     whitelist = Whitelist(get_db(), current_app.config)
@@ -902,11 +901,11 @@ def format_phone_no(number):
     # Return the formatted number
     return separator.join(phone_parts)
 
-def strip_phone_no(phone_no):
+def transform_number(phone_no):
     '''
-    Returns the phone no stripped of all non-alphanumeric characters.
+    Returns the phone no stripped of all non-alphanumeric characters and makes uppercase.
     '''
-    return "".join(filter(str.isalnum, phone_no))
+    return "".join(filter(str.isalnum, phone_no)).upper()
 
 
 def get_db():

--- a/callattendant/userinterface/webapp.py
+++ b/callattendant/userinterface/webapp.py
@@ -320,7 +320,7 @@ def calls():
     calls = []
     for row in result_set:
         number = row[2]
-        phone_no = '{}-{}-{}'.format(number[0:3], number[3:6], number[6:])
+        phone_no = format_phone_no(number)
         # Flask pages use the static folder to get resources.
         # In the static folder we have created a soft-link to the
         # data/messsages folder containing the actual messages.
@@ -403,7 +403,7 @@ def calls_view(call_no):
     caller = {}
     if len(row) > 0:
         number = row[2]
-        phone_no = '{}-{}-{}'.format(number[0:3], number[3:6], number[6:])
+        phone_no = format_phone_no(number)
         # Flask pages use the static folder to get resources.
         # In the static folder we have created a soft-link to the
         # data/messsages folder containing the actual messages.
@@ -503,7 +503,7 @@ def callers_manage(call_no):
         number = record[2]
         caller.update(dict(
             call_no=record[0],
-            phone_no='{}-{}-{}'.format(number[0:3], number[3:6], number[6:]),
+            phone_no=format_phone_no(number),
             name=record[1],
             whitelisted=record[3],
             blacklisted=record[4],
@@ -544,7 +544,7 @@ def callers_blocked():
     records = []
     for record in result_set:
         number = record[0]
-        phone_no = '{}-{}-{}'.format(number[0:3], number[3:6], number[6:])
+        phone_no = format_phone_no(number)
         records.append(dict(
             Phone_Number=phone_no,
             Name=record[1],
@@ -636,7 +636,7 @@ def callers_permitted():
     records = []
     for record in result_set:
         number = record[0]
-        phone_no = '{}-{}-{}'.format(number[0:3], number[3:6], number[6:])
+        phone_no = format_phone_no(number)
         records.append(dict(
             Phone_Number=phone_no,
             Name=record[1],
@@ -763,7 +763,7 @@ def messages():
             msg_no=row[0],
             call_no=row[1],
             name=row[2],
-            phone_no='{}-{}-{}'.format(number[0:3], number[3:6], number[6:]),
+            phone_no=format_phone_no(number),
             wav_file=filepath,
             msg_played=row[5],
             date=date_time.strftime('%d-%b-%y'),

--- a/callattendant/userinterface/webapp.py
+++ b/callattendant/userinterface/webapp.py
@@ -865,7 +865,40 @@ def settings():
 
 
 def format_phone_no(number):
-    return'{}-{}-{}'.format(number[0:3], number[3:6], number[6:])
+    ''' Format the phone number based on a template.'''
+
+    config = current_app.config.get("MASTER_CONFIG")
+    template = config.get("PHONE_DISPLAY_FORMAT")
+    separator = config.get("PHONE_DISPLAY_SEPARATOR")
+    if separator == "" or template == "":
+        return number
+
+    # Get the template and split into reverse ordered parts for processing
+    tmpl_parts = template.split(separator)
+    tmpl_parts.reverse()
+
+    # Piece together the phone no from right to left to handle variable len numbers
+    number_len = len(number)
+    end = number_len
+    total_digits = 0
+    phone_parts = []
+    for tmpl in tmpl_parts:
+        # Assemble parts from right to left
+        start = max(0, end - len(tmpl))
+        digits = number[start: end]
+        phone_parts.insert(0, digits)
+        # Prepare for next part
+        end = start
+        total_digits += len(digits)
+        # if number is shorter than template then exit loop
+        if start == 0:
+            break
+    # If number is longer then template, then capture remaining digits
+    if total_digits < number_len:
+        # Prepend remaining digits to parts
+        phone_parts.insert(0, number[0: number_len - total_digits])
+    # Return the formatted number
+    return separator.join(phone_parts)
 
 
 def get_db():

--- a/tests/test_webapp.py
+++ b/tests/test_webapp.py
@@ -50,6 +50,8 @@ def myapp():
 
         master_config = {
             "DB_FILE": db_path,
+            "PHONE_DISPLAY_FORMAT": "###-###-####",
+            "PHONE_DISPLAY_SEPARATOR": "-",
         }
 
         app.config['MASTER_CONFIG'] = master_config


### PR DESCRIPTION
Adds support for other countries with the following changes:

- Removes the input validation mask on the _Add Permitted Number_ and _Add Blocked Number_ dialogs
- Provides a configurable format string for displaying phone numbers (see `PHONE_DISPLAY_FORMAT` and `PHONE_DISPLAY_SEPARATOR`)
- Accommodates variable length phone numbers (incoming numbers longer or shorter than the `PHONE_DISPLAY_FORMAT` are handled)
- Alpha chars are now allowed in the phone numbers. 
- The use of the _NomoRobo_ online lookup service is now optional (see `BLOCK_SERVICE`). The default is enabled. Countries other than the USA should set this value to `""` (blank) to disable the use of the lookup service.

Fixes #99 
Fixes #111 
Fixes #112 
Fixes #113 
Fixes #114 
