### PR TITLE
Add ability to permit callers based on name and number regex patterns

### DIFF
--- a/callattendant/app.cfg.example
+++ b/callattendant/app.cfg.example
@@ -89,7 +89,13 @@ SCREENED_GREETING_FILE = "resources/general_greeting.wav"
 #   Example: 0 to act immediately, possibly before your local phone rings.
 SCREENED_RINGS_BEFORE_ANSWER = 0
 
+# PERMIT_NAME_PATTERNS: A regex expression dict applied to the CID names
+#   Example: {".*DOE": "Family maybe", "O": "Unknown caller", }
+PERMIT_NAME_PATTERNS = {}
 
+# PERMIT_NUMBER_PATTERNS: A regx expression dict applied to the CID numbers
+#   Example: {"01628": "My area", }
+PERMIT_NUMBER_PATTERNS = {}
 
 # PERMITTED_ACTIONS:  A tuple containing a combination of the following actions:
 #   "greeting", "record_message", "voice_mail". See BLOCKED_ACTIONS for more info.

--- a/callattendant/config.py
+++ b/callattendant/config.py
@@ -40,6 +40,9 @@ default_config = {
     "SCREENED_GREETING_FILE": "resources/general_greeting.wav",
     "SCREENED_RINGS_BEFORE_ANSWER": 0,
 
+    "PERMIT_NAME_PATTERNS": {},
+    "PERMT_NUMBER_PATTERNS": {},
+
     "PERMITTED_ACTIONS": (),
     "PERMITTED_GREETING_FILE": "resources/general_greeting.wav",
     "PERMITTED_RINGS_BEFORE_ANSWER": 4,

--- a/callattendant/config.py
+++ b/callattendant/config.py
@@ -41,7 +41,7 @@ default_config = {
     "SCREENED_RINGS_BEFORE_ANSWER": 0,
 
     "PERMIT_NAME_PATTERNS": {},
-    "PERMT_NUMBER_PATTERNS": {},
+    "PERMIT_NUMBER_PATTERNS": {},
 
     "PERMITTED_ACTIONS": (),
     "PERMITTED_GREETING_FILE": "resources/general_greeting.wav",

--- a/callattendant/screening/callscreener.py
+++ b/callattendant/screening/callscreener.py
@@ -37,7 +37,30 @@ class CallScreener(object):
 
     def is_whitelisted(self, callerid):
         '''Returns true if the number is on a whitelist'''
-        return self._whitelist.check_number(callerid['NMBR'])
+        number = callerid['NMBR']
+        name = callerid["NAME"]
+        permit = self.config.get_namespace("PERMIT_")
+        try:
+            is_whitelisted, reason = self._whitelist.check_number(callerid['NMBR'])
+            if is_whitelisted:
+                return True, reason
+            else:
+                print(">> Checking permitted patterns...")
+                for key in permit["name_patterns"].keys():
+                    match = re.search(key, name)
+                    if match:
+                        reason = permit["name_patterns"][key]
+                        print(reason)
+                        return True, reason
+                for key in permit["number_patterns"].keys():
+                    match = re.search(key, number)
+                    if match:
+                        reason = permit["number_patterns"][key]
+                        print(reason)
+                        return True, reason
+                return False, "Not found"
+        finally:
+            sys.stdout.flush()
 
     def is_blacklisted(self, callerid):
         '''Returns true if the number is on a blacklist'''

--- a/tests/test_callscreener.py
+++ b/tests/test_callscreener.py
@@ -35,16 +35,19 @@ from callattendant.screening.callscreener import CallScreener
 
 
 # Create a blocked caller
-caller1 = {"NAME": "caller1", "NMBR": "1234567890", "DATE": "1012", "TIME": "0600"}
+caller1 = {"NAME": "CALLER1", "NMBR": "1234567890", "DATE": "1012", "TIME": "0600"}
 # Create a permitted caller
-caller2 = {"NAME": "caller2", "NMBR": "1111111111", "DATE": "1012", "TIME": "0600"}
-# Create a V123456789012345 Telemarketer caller
+caller2 = {"NAME": "CALLER2", "NMBR": "1111111111", "DATE": "1012", "TIME": "0600"}
+# Create a V123456789012345 Telemarketer caller (blocked name pattern match)
 caller3 = {"NAME": "V123456789012345", "NMBR": "80512345678", "DATE": "1012", "TIME": "0600"}
 # Create a robocaller
-caller4 = {"NAME": "caller4", "NMBR": "3105241189", "DATE": "1012", "TIME": "0600"}
-# Create a Private Number
-caller5 = {"NAME": "caller5", "NMBR": "P", "DATE": "1012", "TIME": "0600"}
-
+caller4 = {"NAME": "CALLER4", "NMBR": "3105241189", "DATE": "1012", "TIME": "0600"}
+# Create a Private Number (blocked number pattern match)
+caller5 = {"NAME": "CALLER5", "NMBR": "P", "DATE": "1012", "TIME": "0600"}
+# Create a John Doe name (permitted name pattern match)
+caller6 = {"NAME": "JOHN DOE", "NMBR": "0987654321", "DATE": "1012", "TIME": "0600"}
+# Create a unique number (permitted number pattern match)
+caller7 = {"NAME": "CALLER7", "NMBR": "09876543210", "DATE": "1012", "TIME": "0600"}
 
 @pytest.fixture(scope='module')
 def screener():
@@ -62,7 +65,12 @@ def screener():
     config['BLOCK_NUMBER_PATTERNS'] = {
         "P": "Private number",
     }
-
+    config['PERMIT_NAME_PATTERNS'] = {
+        ".*DOE": "Anyone",
+    }
+    config['PERMIT_NUMBER_PATTERNS'] = {
+        "987654": "Anyone",
+    }
     # Create the blacklist to be tested
     screener = CallScreener(db, config)
     # Add a record to the blacklist
@@ -106,3 +114,11 @@ def test_is_blacklisted_by_nomorobo(screener):
 def test_blocked_number_pattern(screener):
     is_blacklisted, reason = screener.is_blacklisted(caller5)
     assert is_blacklisted, "caller1 should be blocked by number pattern"
+
+def test_permitted_name_pattern(screener):
+    is_whitelisted, reason = screener.is_whitelisted(caller6)
+    assert is_whitelisted, "caller6 should be permiteed by name pattern"
+
+def test_permitted_number_pattern(screener):
+    is_whitelisted, reason = screener.is_whitelisted(caller7)
+    assert is_whitelisted, "caller7 should be permiteed by number pattern"


### PR DESCRIPTION
Modfied `callscreener.is_whitelisted` to test incoming name and number against permitted regex patterns defined in the configuration.

- Added PERMIT_NAME_PATTERNS and PERMIT_NUMBER_PATTERNS configuration settings.
- Fixes: #117