### PR TITLE
Fix playing of wav files by USR5637 modem

### DIFF
--- a/callattendant/hardware/modem.py
+++ b/callattendant/hardware/modem.py
@@ -405,7 +405,7 @@ class Modem(object):
                 while data != b'':
                     self._serial.write(data)
                     data = wavefile.readframes(chunk)
-                    # ~ time.sleep(sleep_interval)
+                    time.sleep(sleep_interval)
 
                 self._send(DTE_END_VOICE_DATA_TX)
 


### PR DESCRIPTION
Re-enabled a 120ms sleep interval in `play_audio`.

Fixes #121