### PR TITLE
Refactored threads to ensure clean shutdown

### DIFF
--- a/callattendant/app.py
+++ b/callattendant/app.py
@@ -133,7 +133,7 @@ class CallAttendant(object):
             try:
                 # Wait (blocking) for a caller
                 try:
-                    caller = self._caller_queue.get(False, 3.0)
+                    caller = self._caller_queue.get(True, 3.0)
                 except queue.Empty:
                     continue
 

--- a/callattendant/hardware/modem.py
+++ b/callattendant/hardware/modem.py
@@ -154,7 +154,9 @@ class Modem(object):
         self._serial = serial.Serial()
 
     def open_serial_port(self):
-        """Detects and opens the serial port attached to the modem."""
+        """
+        Detects and opens the serial port attached to the modem.
+        """
         # List all the Serial COM Ports on Raspberry Pi
         proc = subprocess.Popen(['ls /dev/tty[A-Za-z]*'], shell=True, stdout=subprocess.PIPE)
         com_ports = proc.communicate()[0]
@@ -188,12 +190,14 @@ class Modem(object):
         return False
 
     def close_serial_port(self):
-        """Closes the serial port attached to the modem."""
-        print("Closing Serial Port")
+        """
+        Closes the serial port attached to the modem.
+        """
+        print("-> Closing Serial Port")
         try:
             if self._serial.isOpen():
                 self._serial.close()
-                print("Serial Port closed...")
+                print("-> Serial Port closed")
         except Exception as e:
             print(e)
             print("Error: Unable to close the Serial Port.")
@@ -215,10 +219,12 @@ class Modem(object):
 
     def stop(self):
         """
-        Stops the modem thread. Called by the app.
+        Stops the modem thread and releases hardware resources.
         """
         self._stop_event.set()
-        self._thread.join()
+        if self._thread:
+            self._thread.join()
+        self.ring_indicator.close()
 
     def _call_handler(self, handle_caller):
         """
@@ -251,7 +257,7 @@ class Modem(object):
             # This loop reads incoming data from the serial port and
             # posts the caller data to the handle_caller function
             call_record = {}
-            while not self._stop_event.isSet():
+            while not self._stop_event.is_set():
                 modem_data = b''
 
                 # Read from the modem
@@ -317,7 +323,7 @@ class Modem(object):
 
         finally:
             if dev_mode:
-                print("Closing modem log file")
+                print("-> Closing modem log file")
                 logfile.close()
 
     def pick_up(self):

--- a/callattendant/userinterface/webapp.py
+++ b/callattendant/userinterface/webapp.py
@@ -984,7 +984,7 @@ def get_pagination(**kwargs):
 def run_flask(config):
     '''
     Runs the Flask webapp.
-        :param database: full path to the callattendant database file
+        :param config: the application-wide master config object
     '''
     app.secret_key = get_random_string()
     with app.app_context():
@@ -1007,6 +1007,6 @@ def run_flask(config):
 def start(config):
     '''
     Starts the Flask webapp in a separate thread.
-        :param database: full path to the callattendant database file
+        :param config: the application-wide master config object
     '''
     _thread.start_new_thread(run_flask, (config,))

--- a/tests/test_modem.py
+++ b/tests/test_modem.py
@@ -60,7 +60,7 @@ def modem():
 
     yield modem
 
-    modem.ring_indicator.close()
+    modem.stop()
 
 
 def test_profile_reset(modem):

--- a/tests/test_voicemail.py
+++ b/tests/test_voicemail.py
@@ -71,14 +71,15 @@ def modem(db, config):
     modem = Modem(config)
     modem.open_serial_port()
     yield modem
-    modem.ring_indicator.close()
+    modem.stop()
 
 
 @pytest.fixture(scope='module')
 def voicemail(db, config, modem):
 
     voicemail = VoiceMail(db, config, modem)
-    return voicemail
+    yield voicemail
+    voicemail.stop()
 
 
 # Skip the test when running under continous integraion


### PR DESCRIPTION
Refactored classes to gracefully handle shutdown of threads.
- Added `start` methods and `stop` or `shutdown` methods to classes to better convey thread handling methods.
- Now using `_stop_event` Event objects to signal exit of while loops