### PR TITLE
Country code

### DIFF
--- a/callattendant/app.cfg.example
+++ b/callattendant/app.cfg.example
@@ -59,6 +59,10 @@ PHONE_DISPLAY_SEPARATOR = "-"
 #
 PHONE_DISPLAY_FORMAT = "###-###-####"
 
+# Country code for CLI to work, default B5 is USA, B4 is UK
+# see https://opengear.zendesk.com/hc/en-us/articles/216371103-ACM5003-M-Modem-Country-Code-List
+# for others
+COUNTRY_CODE = "B5"
 
 # SCREENING_MODE: A tuple containing: "whitelist" and/or "blacklist", or empty
 SCREENING_MODE = ("whitelist", "blacklist")

--- a/callattendant/config.py
+++ b/callattendant/config.py
@@ -31,6 +31,8 @@ default_config = {
     "PHONE_DISPLAY_SEPARATOR": "-",
     "PHONE_DISPLAY_FORMAT": "###-###-####",
 
+    "COUNTRY_CODE": "B5",
+
     "BLOCK_ENABLED": True,
     "BLOCK_SERVICE": "NOMOROBO",
 

--- a/callattendant/hardware/modem.py
+++ b/callattendant/hardware/modem.py
@@ -83,6 +83,7 @@ TELEPHONE_ANSWERING_DEVICE_ON_HOOK = "AT+VLS=0"   # TAD (DCE) on-hook
 GO_OFF_HOOK = "ATH1"
 GO_ON_HOOK = "ATH0"
 TERMINATE_CALL = "ATH"
+SET_COUNTRY_CODE = "AT+GCI="
 
 # Modem DLE shielded codes - DCE to DTE modem data
 DCE_ANSWER_TONE = (chr(16) + chr(97)).encode()          # <DLE>-a
@@ -824,6 +825,8 @@ class Modem(object):
                 print("Error: Failed to disable local echo mode")
             if not self._send(ENABLE_FORMATTED_CID):
                 print("Error: Failed to enable formatted caller report.")
+            if not self._send(SET_COUNTRY_CODE + self.config["COUNTRY_CODE"]):
+                print("Error: Failed to set country code.")
 
             # Save these settings to a profile
             if not self._send("AT&W0"):

--- a/callattendant/hardware/modem.py
+++ b/callattendant/hardware/modem.py
@@ -825,8 +825,9 @@ class Modem(object):
                 print("Error: Failed to disable local echo mode")
             if not self._send(ENABLE_FORMATTED_CID):
                 print("Error: Failed to enable formatted caller report.")
-            if not self._send(SET_COUNTRY_CODE + self.config["COUNTRY_CODE"]):
-                print("Error: Failed to set country code.")
+            if "COUNTRY_CODE" in self.config:
+                if not self._send(SET_COUNTRY_CODE + self.config["COUNTRY_CODE"]):
+                    print("Error: Failed to set country code.")
 
             # Save these settings to a profile
             if not self._send("AT&W0"):

--- a/tests/test_modem.py
+++ b/tests/test_modem.py
@@ -36,11 +36,12 @@ import pytest
 from callattendant.config import Config
 from callattendant.hardware.modem import Modem, RESET, \
     GET_MODEM_PRODUCT_CODE, GET_MODEM_SETTINGS, \
-    ENTER_VOICE_MODE, TELEPHONE_ANSWERING_DEVICE_OFF_HOOK, \
+    ENTER_VOICE_MODE, SET_COUNTRY_CODE, TELEPHONE_ANSWERING_DEVICE_OFF_HOOK, \
     ENTER_VOICE_TRANSMIT_DATA_STATE, DTE_END_VOICE_DATA_TX, \
     ENTER_VOICE_RECIEVE_DATA_STATE, DTE_END_VOICE_DATA_RX, \
     TERMINATE_CALL, ETX_CODE, DLE_CODE, \
-    SET_VOICE_COMPRESSION, SET_VOICE_COMPRESSION_CONEXANT
+    SET_VOICE_COMPRESSION, SET_VOICE_COMPRESSION_CONEXANT, \
+    SET_COUNTRY_CODE
 
 global SET_VOICE_COMPRESSION
 
@@ -70,6 +71,10 @@ def test_modem_online(modem):
 
 def test_profile_reset(modem):
     assert modem._send(RESET)
+
+
+def test_country_code(modem):
+    assert modem._send(SET_COUNTRY_CODE+"B5")
 
 
 def test_get_modem_settings(modem):


### PR DESCRIPTION
Added setting to enable the setting of the modem country code in the app.cfg file.

If the COUNTRY_CODE does not exist in the app.cfg file it retains the default setting, this is required with several modems that do not have flash ram as the setting is lost on power down.  Now it is set at init time.