### PR TITLE
Use the default bs4 parser instead of lxml.

### DIFF
--- a/callattendant/screening/nomorobo.py
+++ b/callattendant/screening/nomorobo.py
@@ -37,7 +37,7 @@ class NomoroboService(object):
         headers = {}
         allowed_codes = [404]  # allow not found response
         content = self.http_get(url, headers, allowed_codes)
-        soup = BeautifulSoup(content, "lxml")  # lxml HTML parser: fast
+        soup = BeautifulSoup(content, "html.parser")
 
         score = 0  # = no spam
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,6 @@ gpiozero==1.5.1
 iso8601==0.1.12
 itsdangerous==1.1.0
 Jinja2==2.11.2
-lxml==4.5.2
 MarkupSafe==1.1.1
 pigpio==1.46
 pygments


### PR DESCRIPTION
BS4 on some OSs (notably OSX, and the most recent Raspberry Pi OS) does not reliably find lxml, even when installed.

E.g:
https://stackoverflow.com/questions/24398302/bs4-featurenotfound-couldnt-find-a-tree-builder-with-the-features-you-requeste