### PR TITLE
MultiMobile MT9234MU modem support and minor improvement to hang-up detection

### DIFF
--- a/callattendant/app.cfg.example
+++ b/callattendant/app.cfg.example
@@ -20,6 +20,14 @@ DEBUG = False
 # TESTING: If True function tests are executed in lieu of normal operation
 TESTING = False
 
+# REC_VM_MAX_DURATION: How long to record voicemail / message in seconds Default 120
+REC_VM_MAX_DURATION = 120
+
+# SERIAL_BAUD_RATE: # Serial Baud Rate 57600 for USR and CONEXANT, 115200 MT9234MU. 115200 could work for USR and CONEXANT based modem too.
+# MT9234MU seems to requrie 115200 baud rate to produce good audio quality.
+
+SERIAL_BAUD_RATE = 57600
+
 # DATABASE: Sqlite database for incoming call log, whitelist and blacklist
 #   This should not be changed/overrriden except during development/testing
 #DATABASE = "callattendant.db"

--- a/callattendant/config.py
+++ b/callattendant/config.py
@@ -19,11 +19,14 @@ from werkzeug.utils import import_string
 # and screened callers through to the home phone.
 #
 default_config = {
-    "VERSION": '1.1.1',
+    "VERSION": '1.1.2',
 
     "ENV": 'production',
     "DEBUG": False,
     "TESTING": False,
+
+    "REC_VM_MAX_DURATION": 120,
+    "SERIAL_BAUD_RATE": 57600,
 
     "DATABASE": "callattendant.db",
     "SCREENING_MODE": ("whitelist", "blacklist"),
@@ -172,6 +175,12 @@ class Config(dict):
             success = False
         if not isinstance(self["TESTING"], bool):
             print("* TESTING should be bool: {}".format(type(self["TESTING"])))
+            success = False
+        if not isinstance(self["REC_VM_MAX_DURATION"], int):
+            print("* REC_VM_MAX_DURATION should be an integer: {}".format(type(self["REC_VM_MAX_DURATION"])))
+            success = False
+        if not isinstance(self["SERIAL_BAUD_RATE"], int):
+            print("* SERIAL_BAUD_RATE should be an integer: {}".format(type(self["SERIAL_BAUD_RATE"])))
             success = False
         if not isinstance(self["BLOCK_ENABLED"], bool):
             print("* BLOCK_ENABLED should be a bool: {}".format(type(self["BLOCK_ENABLED"])))


### PR DESCRIPTION
- Added support for MultiMobile MT9234MU
- Added REC_VM_MAX_DURATION and SERIAL_BAUD_RATE to configuration. SERIAL_BAUD_RATE for MT9234MU should be 115200 for the best audio quality from testing
- Added dial tone detection to message recording
- Disabled internal speaker on modem init. MT9234MU has built in speaker
- Bumped version to 1.1.2